### PR TITLE
Fix existing-output handling, tab bar crash, CLI args, and antivirus false positives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,9 @@ name: CI
 on:
   push:
     branches: [main]
-    tags: ['v*']
+    # Release tags in this repo have no "v" prefix, e.g. 1.16.0. The leading
+    # digit keeps non-release tags like converter-bundle from triggering a build.
+    tags: ['[0-9]*']
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -135,7 +137,7 @@ jobs:
     name: Publish release
     runs-on: ubuntu-latest
     needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,153 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Run unit tests
+        run: python -m pytest -q
+
+      - name: Smoke-test the GUI headlessly
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libegl1 libxkbcommon-x11-0 libxcb-cursor0 \
+            libxcb-icccm4 libxcb-keysyms1 libxcb-shape0 libxcb-xinerama0
+          python - <<'PY'
+          import sys
+          sys.path.insert(0, "src")
+          # Import every module so syntax/import errors fail the build, then
+          # build the main window offscreen to catch Qt wiring regressions.
+          from PyQt6.QtWidgets import QApplication
+          import gui_main
+          from gui_main import WhisperGUI
+
+          for m in ("check_hardware_optimization", "check_yt_dlp_version", "check_app_update"):
+              setattr(WhisperGUI, m, lambda self: None)
+          WhisperGUI.check_and_setup_dependencies = lambda self: True
+
+          app = QApplication([])
+          win = WhisperGUI()
+          win.resize(1250, 820)
+          win.show()
+          app.processEvents()
+
+          assert win.tabs.count() > 0, "no tabs were created"
+          assert win._required_tab_bar_width(), "tab bar measurement failed"
+
+          # These only run in frozen builds, so nothing else exercises them.
+          sys.frozen = True
+          win._apply_tab_minimums()
+          win._enforce_splitter_sizes_for_frozen()
+          win.resize(1300, 840)
+          app.processEvents()
+
+          print(f"OK: {win.tabs.count()} tabs, window {win.width()}x{win.height()}")
+          PY
+
+  build:
+    name: Windows build
+    runs-on: windows-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller
+
+      - name: Build executable
+        run: pyinstaller --noconfirm --clean faster-whisper-xxl-gui.spec
+
+      - name: Verify the packaged app starts
+        shell: pwsh
+        timeout-minutes: 5
+        run: |
+          # Builds the real main window inside the packaged exe. Catches an
+          # `excludes` entry that removed something still needed, which would
+          # otherwise only show up as a crash on a user's machine.
+          $p = Start-Process -FilePath "dist/faster-whisper-xxl-gui.exe" `
+                             -ArgumentList "--selftest" -Wait -PassThru
+          if (Test-Path "dist/selftest.log") { Get-Content "dist/selftest.log" }
+          if ($p.ExitCode -ne 0) {
+            throw "Packaged app failed to start (exit $($p.ExitCode)). A PyInstaller exclude probably removed something needed."
+          }
+          Write-Host "Packaged app starts cleanly."
+
+      - name: Report size and checksum
+        shell: pwsh
+        run: |
+          $exe = "dist/faster-whisper-xxl-gui.exe"
+          $bytes = (Get-Item $exe).Length
+          $mb = [math]::Round($bytes / 1MB, 1)
+          Write-Host "Size: $bytes bytes ($mb MiB)"
+          # Microsoft's false-positive submission portal caps uploads at 50 MB.
+          if ($bytes -gt 50000000) {
+            Write-Warning "Over the 50 MB limit of Microsoft's submission portal."
+          } else {
+            Write-Host "Under the 50 MB submission limit."
+          }
+          $hash = (Get-FileHash $exe -Algorithm SHA256).Hash.ToLower()
+          "$hash  faster-whisper-xxl-gui.exe" | Out-File -Encoding ascii dist/faster-whisper-xxl-gui.exe.sha256
+          Write-Host "SHA256: $hash"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: faster-whisper-xxl-gui-windows
+          path: |
+            dist/faster-whisper-xxl-gui.exe
+            dist/faster-whisper-xxl-gui.exe.sha256
+          retention-days: 30
+
+  release:
+    name: Publish release
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: faster-whisper-xxl-gui-windows
+          path: dist
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/faster-whisper-xxl-gui.exe
+            dist/faster-whisper-xxl-gui.exe.sha256
+          draft: true
+          generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ build/
 dist/
 logs/
 __pycache__
-faster-whisper-xxl-gui.spec
 *.json
 *.txt
 bundle/
@@ -11,3 +10,4 @@ conv_env/
 fwxxl-converter-win-x64.zip
 fwxxl-converter-win-x64.sha256
 tools/
+selftest.log

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Faster Whisper XXL GUI is a desktop interface for the Faster Whisper XXL transcr
 - Model/task/language controls plus VAD and audio options.
 - Model Manager with custom HF/local models and Transformers -> CT2 conversion.
 - Multiple output formats (SRT, VTT, JSON, TXT, etc.).
+- Skip or overwrite existing outputs, for resuming interrupted batches.
 - Light/Dark/AMOLED themes.
 - Persistent settings.
 
@@ -19,6 +20,12 @@ Faster Whisper XXL GUI is a desktop interface for the Faster Whisper XXL transcr
 1. Download the latest `.exe` from the [Releases](https://github.com/cbro33/Faster-Whisper-XXL-GUI/releases) page.
 2. Run it (no installation required).
 3. On first launch, accept the prompt to download and set up Faster Whisper XXL + FFmpeg.
+
+## Antivirus False Positives
+
+Some antivirus products flag the `.exe` as a trojan, usually when it first downloads a model or the Faster Whisper XXL archive. This is a false positive: the release is an unsigned PyInstaller build, and antivirus engines score that packaging heavily on its own.
+
+Add an exclusion for the app folder, or run from source instead. Reporting the file to your antivirus vendor as a false positive helps everyone using that product. Microsoft Defender submissions go [here](https://www.microsoft.com/en-us/wdsi/filesubmission). See the [Wiki](https://github.com/cbro33/Faster-Whisper-XXL-GUI/wiki) for details.
 
 ## Manual yt-dlp Updates (No Python)
 

--- a/WIKI.md
+++ b/WIKI.md
@@ -13,6 +13,7 @@ This document provides an in-depth explanation of all the settings and options a
     *   [Output Dir](#output-dir)
     *   [Output Location](#output-location)
     *   [Output Name](#output-name)
+    *   [Existing Outputs](#existing-outputs)
     *   [Model](#model)
     *   [Model Manager (Custom Models)](#model-manager-custom-models)
     *   [Transformers -> CTranslate2 Conversion](#transformers---ctranslate2-conversion)
@@ -49,6 +50,8 @@ This document provides an in-depth explanation of all the settings and options a
     *   [VRAM (GPU Memory)](#vram-gpu-memory)
     *   [Storage](#storage)
     *   [Recommended Configurations](#recommended-configurations)
+9.  [Troubleshooting](#9-troubleshooting)
+    *   [Antivirus Flags the App or a Download](#antivirus-flags-the-app-or-a-download)
 
 ---
 
@@ -105,6 +108,18 @@ These settings apply broadly to the transcription process and are crucial for pe
 *   **Description:** Controls output filename base behavior.
 *   **Option:** `Use input filename for outputs`
 *   **Behavior:** When checked, output files use the original media filename with transcription format extensions (`.srt`, `.txt`, etc.). When unchecked, default naming behavior is used.
+
+### Existing Outputs
+
+*   **Description:** Controls what happens when a file's outputs are already present in the output folder.
+*   **Options:** `Add suffix`, `Skip file`, `Overwrite`.
+*   **Behavior:**
+    *   **`Add suffix`** *(default, unchanged from previous versions)*: Writes the new output under a suffixed name, e.g. `video_mp4.srt`.
+    *   **`Skip file`**: Leaves the existing outputs untouched and moves on to the next file. The console reports each skipped file and prints a total when the batch ends. This is the only mode that guarantees existing files are not rewritten.
+    *   **`Overwrite`**: Replaces the existing outputs in place, with no suffixed copies.
+*   **Note:** A file is only skipped when **every** selected output format is already present. If a previous run was interrupted partway through writing its formats, the file is re-processed and the console explains which format was missing. This makes `Skip file` safe for resuming a large interrupted batch.
+*   **Note:** If an earlier run wrote suffixed outputs (`video_mp4.srt`), the app remembers that name and checks against it, so re-running with `Skip file` recognizes the work as done.
+*   **Note:** Faster Whisper XXL only honors `--skip` when its input is a wildcard or a directory. This app passes it one file at a time, so `--skip` in **Extra CLI Args** has no effect. Use this setting instead.
 
 ### Model
 
@@ -228,6 +243,8 @@ These settings provide more granular control over the Whisper model's behavior.
 *   **Description:** Free-form command-line arguments passed directly to Faster Whisper XXL for advanced options not exposed in the UI. Located in the Paths and Overrides tab.
 *   **Usage:** Enter flags as you would on the command line (e.g., `--diarize --vad_clip_duration 30`). These are appended to the command and can override earlier settings.
 *   **Tip:** Run the Faster Whisper XXL executable with `--help` to see available flags.
+*   **Note:** Flags that require Faster Whisper XXL to receive a wildcard or a folder as its input have no effect here, because the app runs it once per file with an explicit path. This applies to `--skip`, `--batch_recursive` and `--check_files`; the app prints a note in the console if it sees one of them. For skipping already-transcribed files use [Existing Outputs](#existing-outputs), and to process a whole folder use **Add Folder** in the File tab.
+*   **Note:** Everything else is passed through unchanged, and extra arguments are appended last, so they override the equivalent GUI settings.
 
 ### Word Timestamps
 
@@ -359,3 +376,26 @@ The performance of Faster Whisper XXL is heavily dependent on your hardware, par
     *   **Settings:** `large`, `large-v2`, or `large-v3` model, `cuda` device, `float16` compute type.
 
 By carefully selecting your settings based on your hardware and the characteristics of your audio, you can optimize the performance and accuracy of your transcriptions with Faster Whisper XXL GUI.
+
+---
+
+## 9. Troubleshooting
+
+### Antivirus Flags the App or a Download
+
+Some antivirus products report the app as a trojan, most often the first time it downloads a model, the Faster Whisper XXL archive, or the converter bundle. **This is a false positive.**
+
+**Why it happens**
+
+The Windows release is built with PyInstaller and is not code-signed. Antivirus engines score unsigned PyInstaller executables heavily on their own, because the same packaging is popular with malware authors. Downloading files then writing them to disk matches the behavioral pattern of a dropper, so the detection usually fires during setup or a model download rather than at launch. It is the packaging that is being flagged, not anything in the transcription or download code.
+
+**What you can do**
+
+*   Add an exclusion for the app folder (and the `bin` and model folders) in your antivirus settings.
+*   Report the file to your antivirus vendor as a false positive. Vendors do act on these, and it fixes the problem for everyone using that product, not just you. Microsoft Defender submissions go to the [Microsoft Security Intelligence portal](https://www.microsoft.com/en-us/wdsi/filesubmission) and are usually reviewed within a few days.
+*   Verify the download is genuine before excluding it: only download releases from the [official Releases page](https://github.com/cbro33/Faster-Whisper-XXL-GUI/releases), and check the file on [VirusTotal](https://www.virustotal.com/). A handful of engines flagging it while the major ones do not is the signature of a false positive.
+*   Run from source instead. Python scripts are not packed executables and do not trigger the same heuristics. See [Run From Source](https://github.com/cbro33/Faster-Whisper-XXL-GUI#run-from-source).
+
+**What would actually fix it**
+
+An Authenticode code-signing certificate, which is the only thing that reliably clears these detections. Certificates are a recurring paid cost that this project does not currently cover. Until then the app avoids the things that make the situation worse: the build is not UPX-packed, and every network request identifies itself with a proper `User-Agent`.

--- a/faster-whisper-xxl-gui.spec
+++ b/faster-whisper-xxl-gui.spec
@@ -1,0 +1,81 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+a = Analysis(
+    ['src/faster-whisper-xxl-gui.py'],
+    pathex=[],
+    binaries=[],
+    datas=[('resources', 'resources')],
+    hiddenimports=[
+        'yt_dlp', 
+        'yt_dlp.extractor', 
+        'requests', 
+        'tempfile', 
+        'subprocess', 
+        'threading',
+        'webbrowser',
+        'pathlib',
+        'logging',
+        'json',
+        'platform',
+        'shutil',
+        'PyQt6.QtCore',
+        'PyQt6.QtGui', 
+        'PyQt6.QtWidgets',
+        'py7zr'
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    # The app only uses QtCore/QtGui/QtWidgets, but PyInstaller bundles every
+    # Qt module it can find. Trimming these keeps the exe under the 50 MB limit
+    # of Microsoft's false-positive submission portal (see issue #21) and cuts
+    # the download size. Deliberately conservative: QtNetwork, QtSvg, QtOpenGL
+    # and QtPrintSupport are left in because QtWidgets can pull them in
+    # indirectly. torch/pynvml are optional GPU-detection imports guarded by
+    # `except ImportError` in gpu_utils.py, and are not bundled today anyway.
+    excludes=[
+        'PyQt6.QtWebEngineCore', 'PyQt6.QtWebEngineWidgets', 'PyQt6.QtWebEngineQuick',
+        'PyQt6.QtQml', 'PyQt6.QtQuick', 'PyQt6.QtQuick3D', 'PyQt6.QtQuickWidgets',
+        'PyQt6.Qt3DCore', 'PyQt6.Qt3DRender', 'PyQt6.Qt3DExtras',
+        'PyQt6.Qt3DInput', 'PyQt6.Qt3DLogic', 'PyQt6.Qt3DAnimation',
+        'PyQt6.QtCharts', 'PyQt6.QtDataVisualization',
+        'PyQt6.QtMultimedia', 'PyQt6.QtMultimediaWidgets',
+        'PyQt6.QtBluetooth', 'PyQt6.QtNfc', 'PyQt6.QtPositioning', 'PyQt6.QtLocation',
+        'PyQt6.QtSerialPort', 'PyQt6.QtWebSockets', 'PyQt6.QtWebChannel',
+        'PyQt6.QtSql', 'PyQt6.QtTest', 'PyQt6.QtDesigner', 'PyQt6.QtHelp',
+        'PyQt6.QtPdf', 'PyQt6.QtPdfWidgets',
+        'tkinter',
+        'torch', 'torchvision', 'torchaudio',
+        'numpy', 'scipy', 'pandas', 'matplotlib', 'PIL',
+        'IPython', 'jupyter', 'notebook', 'pytest', '_pytest',
+    ],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='faster-whisper-xxl-gui',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    # Keep UPX off. Packed executables are one of the strongest antivirus
+    # heuristic triggers, and this build is unsigned, so it has no signature to
+    # offset that. Builds so far were unpacked only because UPX happened not to
+    # be installed -- this makes it deliberate. See issue #21.
+    upx=False,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/src/config.py
+++ b/src/config.py
@@ -1,5 +1,14 @@
 
 APP_VERSION = "1.16.0"
+
+# Sent on every outbound request. A bare "python-requests/x.y" User-Agent from an
+# unsigned executable is a mild antivirus heuristic trigger, and both GitHub and
+# Hugging Face ask clients to identify themselves.
+APP_USER_AGENT = (
+    f"Faster-Whisper-XXL-GUI/{APP_VERSION} "
+    "(+https://github.com/cbro33/Faster-Whisper-XXL-GUI)"
+)
+HTTP_HEADERS = {"User-Agent": APP_USER_AGENT}
 SUPPORTED_EXTENSIONS = ('.mp3', '.wav', '.mp4', '.m4a', '.flac', '.aac', '.ogg', '.webm', '.mkv', '.avi', '.mov')
 YTDLP_UPDATE_FAILURE_COOLDOWN_HOURS = 6
 YTDLP_DEBUG_LOG_NAME = "ytdlp_update_debug.log"

--- a/src/config.py
+++ b/src/config.py
@@ -1,5 +1,5 @@
 
-APP_VERSION = "1.16.0"
+APP_VERSION = "1.17.0"
 
 # Sent on every outbound request. A bare "python-requests/x.y" User-Agent from an
 # unsigned executable is a mild antivirus heuristic trigger, and both GitHub and

--- a/src/converter_utils.py
+++ b/src/converter_utils.py
@@ -15,10 +15,11 @@ from config import (
     CONVERTER_BUNDLE_ASSET,
     CONVERTER_BUNDLE_SHA256_ASSET,
     CONVERTER_BUNDLE_DIR_NAME,
+    HTTP_HEADERS,
 )
 from utils import get_settings_directory
 
-GITHUB_HEADERS = {"User-Agent": f"Faster-Whisper-XXL-GUI/{APP_VERSION}"}
+GITHUB_HEADERS = dict(HTTP_HEADERS)
 
 _WEIGHT_FILENAMES = {"model.safetensors", "pytorch_model.bin"}
 

--- a/src/faster-whisper-xxl-gui.py
+++ b/src/faster-whisper-xxl-gui.py
@@ -2,6 +2,7 @@ import sys
 import os
 import json
 import logging
+import traceback
 import faulthandler
 from PyQt6.QtWidgets import QApplication
 from PyQt6.QtCore import Qt
@@ -48,7 +49,68 @@ _configure_logging()
 
 from gui_main import WhisperGUI
 
+
+def _run_selftest():
+    """Headless startup check used by CI. Exits 0 if the build is sound.
+
+    A packaged build can be broken in ways source runs never show: a PyInstaller
+    `excludes` entry that removed something still needed, or a missing Qt plugin.
+    Both surface as a crash on the user's machine. This builds the real main
+    window offscreen so the packaged app is exercised end to end, without
+    needing a display or the Faster Whisper XXL binary.
+    """
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+    # Startup work that needs the network or shows a dialog would block a
+    # non-interactive run, and none of it tells us whether the bundle is intact.
+    for name in ("check_hardware_optimization", "check_yt_dlp_version", "check_app_update"):
+        setattr(WhisperGUI, name, lambda self: None)
+    WhisperGUI.check_and_setup_dependencies = lambda self: True
+
+    app = QApplication(sys.argv)
+    window = WhisperGUI()
+    window.resize(1250, 820)
+    window.show()
+    app.processEvents()
+
+    if not window.tabs.count():
+        raise RuntimeError("no tabs were created")
+    if not window._required_tab_bar_width():
+        raise RuntimeError("tab bar could not be measured")
+
+    # Only reached in frozen builds, so nothing else covers these.
+    sys.frozen = True
+    window._apply_tab_minimums()
+    window._enforce_splitter_sizes_for_frozen()
+    window.resize(1300, 840)
+    app.processEvents()
+
+    message = f"selftest OK: {window.tabs.count()} tabs, {window.width()}x{window.height()}"
+    logging.info(message)
+    print(message)
+    # console=False builds have no stdout, so leave a file CI can read too.
+    try:
+        with open(os.path.join(get_app_directory(), "selftest.log"), "w", encoding="utf-8") as handle:
+            handle.write(message + "\n")
+    except Exception:
+        pass
+    return 0
+
+
 def main():
+    if "--selftest" in sys.argv:
+        try:
+            sys.exit(_run_selftest())
+        except Exception:
+            logging.exception("selftest failed")
+            traceback.print_exc()
+            try:
+                with open(os.path.join(get_app_directory(), "selftest.log"), "w", encoding="utf-8") as handle:
+                    handle.write("selftest FAILED\n" + traceback.format_exc())
+            except Exception:
+                pass
+            sys.exit(1)
+
     if hasattr(Qt.ApplicationAttribute, 'AA_EnableHighDpiScaling'):
         QApplication.setAttribute(Qt.ApplicationAttribute.AA_EnableHighDpiScaling, True)
     if hasattr(Qt.ApplicationAttribute, 'AA_UseHighDpiPixmaps'):

--- a/src/gui_components.py
+++ b/src/gui_components.py
@@ -26,7 +26,7 @@ from PyQt6.QtCore import pyqtSignal, Qt, QTimer
 from PyQt6.QtGui import QDragEnterEvent, QDropEvent
 from utils import get_window_stays_on_top_flag, run_hidden_subprocess, get_app_directory, find_7zip
 from gpu_utils import detect_hardware_capabilities, get_recommended_settings
-from config import SUPPORTED_EXTENSIONS
+from config import SUPPORTED_EXTENSIONS, HTTP_HEADERS
 from converter_utils import find_transformers_weight_files, get_converter_bundle_dir, get_converter_python_path
 from workers import ModelConversionWorker
 
@@ -500,7 +500,7 @@ class DownloadManager(QDialog):
 
     def download_worker(self):
         try:
-            response = requests.get(self.url, stream=True, timeout=15)
+            response = requests.get(self.url, stream=True, timeout=15, headers=HTTP_HEADERS)
             response.raise_for_status()
             total_size = int(response.headers.get('content-length', 0))
 
@@ -819,7 +819,7 @@ class ModelDownloadDialog(QDialog):
         url = f"https://huggingface.co/{self.repo_id}/resolve/main/{filename}"
         try:
             # First, try HEAD request for Content-Length
-            head_resp = requests.head(url, allow_redirects=True, timeout=5)
+            head_resp = requests.head(url, allow_redirects=True, timeout=5, headers=HTTP_HEADERS)
             if head_resp.status_code == 200:
                 content_length = int(head_resp.headers.get("content-length", 0))
                 if content_length > 0:
@@ -833,7 +833,7 @@ class ModelDownloadDialog(QDialog):
 
         # If HEAD failed or gave 0, try GET request and parse content-length or use API
         try:
-            get_resp = requests.get(url, stream=True, timeout=5)
+            get_resp = requests.get(url, stream=True, timeout=5, headers=HTTP_HEADERS)
             if get_resp.status_code == 200:
                 content_length = int(get_resp.headers.get("content-length", 0))
                 if content_length > 0:
@@ -869,7 +869,7 @@ class ModelDownloadDialog(QDialog):
         
         try:
             api_url = f"https://huggingface.co/api/models/{self.repo_id}"
-            resp = requests.get(api_url, timeout=5)
+            resp = requests.get(api_url, timeout=5, headers=HTTP_HEADERS)
             if resp.status_code == 200:
                 data = resp.json()
                 for sibling in data.get("siblings", []):
@@ -886,7 +886,7 @@ class ModelDownloadDialog(QDialog):
 
     def _fetch_repo_file_list(self):
         api_url = f"https://huggingface.co/api/models/{self.repo_id}"
-        resp = requests.get(api_url, timeout=10)
+        resp = requests.get(api_url, timeout=10, headers=HTTP_HEADERS)
         if resp.status_code != 200:
             raise RuntimeError("Failed to fetch repo file list.")
         data = resp.json()
@@ -1002,7 +1002,7 @@ class ModelDownloadDialog(QDialog):
                 "[%s] aux download start total=%s", self._debug_id, total
             )
         
-        response = requests.get(url, stream=True, timeout=30)
+        response = requests.get(url, stream=True, timeout=30, headers=HTTP_HEADERS)
         self._active_response = response
         if response.status_code == 404:
             if required:
@@ -1054,7 +1054,7 @@ class ModelDownloadDialog(QDialog):
         url = f"https://huggingface.co/{self.repo_id}/resolve/main/{filename}"
         self.download_progress.emit(0, 0, f"{filename}@@init")
         
-        response = requests.get(url, stream=True, timeout=30)
+        response = requests.get(url, stream=True, timeout=30, headers=HTTP_HEADERS)
         self._active_response = response
         if response.status_code == 404:
             raise FileNotFoundError(f"{filename} not found.")

--- a/src/gui_main.py
+++ b/src/gui_main.py
@@ -24,7 +24,7 @@ from PyQt6.QtWidgets import (
 from PyQt6.QtCore import Qt, QTimer, QProcess, QProcessEnvironment, QByteArray, QUrl, QThread, pyqtSignal, QModelIndex
 from PyQt6.QtGui import QIcon, QPalette, QColor, QTextCursor, QFont, QDesktopServices, QFontMetrics, QAction
 
-from config import APP_VERSION, SUPPORTED_EXTENSIONS
+from config import APP_VERSION, SUPPORTED_EXTENSIONS, HTTP_HEADERS
 from utils import (
     get_app_directory, get_settings_directory, get_portable_settings_directory,
     resource_path, format_path_for_display, detect_faster_whisper_binary_version,
@@ -87,6 +87,7 @@ from output_formats import (
     create_sentences_only,
     build_lrc_lines,
     extra_args_has_flag,
+    find_existing_outputs,
 )
 
 MODEL_DIR_PREFIX = "faster-whisper-"
@@ -95,7 +96,7 @@ BUILTIN_MODELS = [
     "large-v1", "large-v2", "large-v3", "large-v3-turbo",
     "distil-large-v2", "distil-large-v3", "distil-medium.en", "distil-small.en",
 ]
-GITHUB_HEADERS = {"User-Agent": f"Faster-Whisper-XXL-GUI/{APP_VERSION}"}
+GITHUB_HEADERS = dict(HTTP_HEADERS)
 
 from model_manager import ModelManagerDialog  # noqa: E402 — after MODULE_DIR_PREFIX is defined
 from gui_tabs import TabSetupMixin
@@ -173,7 +174,8 @@ class WhisperGUI(QMainWindow, TabSetupMixin, InfoDialogsMixin):
         self._last_review_output_dir = None
         self._last_review_output_base = None
         self._shown_ytdlp_403_hint = False
-        
+        self._skipped_existing_count = 0
+
         if not self.check_and_setup_dependencies():
             QTimer.singleShot(0, self.close)
             return
@@ -402,14 +404,24 @@ class WhisperGUI(QMainWindow, TabSetupMixin, InfoDialogsMixin):
         QTimer.singleShot(0, self._enforce_splitter_sizes_for_frozen)
 
     def _required_tab_bar_width(self):
+        """Width the tab bar needs to show every tab without scroll arrows.
+
+        QTabBar.tabSizeHint is protected, and the bar QTabWidget creates for us
+        lives on the C++ side, so calling it raises RuntimeError under PyQt6.
+        That made this whole function throw in frozen builds, where it is the
+        only caller path, leaving the tab bar permanently clipped. The bar's
+        public sizeHint already accounts for every tab.
+        """
         if not getattr(self, "tabs", None):
             return None
-        tab_bar = self.tabs.tabBar()
-        total = 20
-        for idx in range(self.tabs.count()):
-            hint = tab_bar.tabSizeHint(idx)
-            total += hint.width() + 2
-        return total
+        try:
+            hint = self.tabs.tabBar().sizeHint().width()
+        except Exception as exc:
+            logging.debug("Could not measure tab bar width: %s", exc)
+            return None
+        if hint <= 0:
+            return None
+        return hint + 20  # room for the panel's own margins
 
     def _apply_tab_minimums(self):
         if not getattr(sys, "frozen", False):
@@ -1189,19 +1201,86 @@ class WhisperGUI(QMainWindow, TabSetupMixin, InfoDialogsMixin):
             source_base = original_base
         if not source_base or source_base == target_base:
             return
+        overwrite = self._get_existing_output_mode() == "overwrite"
         extensions = ["srt", "vtt", "txt", "tsv", "json", "lrc"]
         for ext in extensions:
             src = os.path.join(output_dir, f"{source_base}.{ext}")
             if not os.path.exists(src):
                 continue
             dst = os.path.join(output_dir, f"{target_base}.{ext}")
-            if os.path.exists(dst):
+            if os.path.exists(dst) and not overwrite:
                 logging.warning("Output already exists, skipping rename: %s", dst)
                 continue
             try:
-                os.rename(src, dst)
+                # os.replace overwrites atomically; plain rename fails on Windows
+                # when the destination exists.
+                os.replace(src, dst)
             except Exception as exc:
                 logging.warning("Failed to rename output %s -> %s: %s", src, dst, exc)
+
+    def _get_existing_output_mode(self):
+        """How to handle a file whose outputs already exist: suffix/skip/overwrite."""
+        combo = getattr(self, "existing_output_combo", None)
+        if combo is None:
+            return "suffix"
+        mode = combo.currentData()
+        return mode if mode in ("suffix", "skip", "overwrite") else "suffix"
+
+    def _get_selected_output_format_labels(self):
+        """GUI format labels the user has checked, defaulting to srt when none."""
+        if self.output_format_checkboxes.get('all') and self.output_format_checkboxes['all'].isChecked():
+            return ['all']
+        labels = [
+            fmt for fmt, cb in self.output_format_checkboxes.items()
+            if fmt != 'all' and cb.isChecked()
+        ]
+        return labels or ['srt']
+
+    def _check_existing_outputs(self, input_file_path):
+        """Decide whether *input_file_path* can be skipped because it is done.
+
+        Returns ``(should_skip, note)``; *note* is an optional console line
+        explaining the decision, and is only produced when some outputs exist.
+        """
+        if self._get_existing_output_mode() != "skip":
+            return False, None
+        output_dir = self.get_output_dir(input_file_path)
+        if not output_dir:
+            return False, None
+        basename = self._get_existing_output_basename(input_file_path, output_dir)
+        existing, missing = find_existing_outputs(
+            output_dir, basename, self._get_selected_output_format_labels()
+        )
+        if existing and not missing:
+            return True, f"Skipped: outputs already exist for {basename}"
+        if existing:
+            # Partial outputs mean an interrupted run, so redo it but say why.
+            missing_names = ", ".join(os.path.basename(path) for path in missing)
+            return False, f"Not skipped: {basename} is missing {missing_names}"
+        return False, None
+
+    def _report_skipped_summary(self):
+        """Print how many files a finished batch skipped, then reset the count."""
+        count = getattr(self, "_skipped_existing_count", 0)
+        if count:
+            plural = "file" if count == 1 else "files"
+            self._append_text_to_console(
+                f"\nSkipped {count} {plural} with existing outputs.\n"
+            )
+        self._skipped_existing_count = 0
+
+    def _get_existing_output_basename(self, input_file_path, output_dir):
+        """Basename a previous run used for this input, else the plain input stem.
+
+        Checking against the recorded basename matters when an earlier run was
+        suffixed (``video_mp4``), because its outputs live under that name, not
+        ``video``.
+        """
+        map_key = self._make_output_map_key(input_file_path, output_dir)
+        stored_base = self._output_basename_map.get(map_key)
+        if stored_base:
+            return stored_base
+        return os.path.splitext(os.path.basename(input_file_path))[0]
 
     def _compute_output_basename(self, input_file_path, output_dir, force_suffix=False):
         original_base = os.path.splitext(os.path.basename(input_file_path))[0]
@@ -1210,6 +1289,10 @@ class WhisperGUI(QMainWindow, TabSetupMixin, InfoDialogsMixin):
             return original_base
         if force_suffix:
             return f"{original_base}_{original_ext}"
+        if self._get_existing_output_mode() == "overwrite":
+            # Reuse whatever name the previous run wrote so we replace it in
+            # place instead of adding a collision suffix.
+            return self._get_existing_output_basename(input_file_path, output_dir)
         map_key = self._make_output_map_key(input_file_path, output_dir)
         stored_base = self._output_basename_map.get(map_key)
         if stored_base:
@@ -2191,6 +2274,8 @@ class WhisperGUI(QMainWindow, TabSetupMixin, InfoDialogsMixin):
         self.vad_device.currentTextChanged.connect(self.save_combo_setting)
         self.diarize_backend.currentTextChanged.connect(self.save_combo_setting)
         self.diarize_device.currentTextChanged.connect(self.save_combo_setting)
+        if getattr(self, "existing_output_combo", None):
+            self.existing_output_combo.currentIndexChanged.connect(self.save_combo_setting)
         self.temperature.valueChanged.connect(self.save_spinbox_setting)
         self.beam_size.valueChanged.connect(self.save_spinbox_setting)
         self.best_of.valueChanged.connect(self.save_spinbox_setting)
@@ -2204,6 +2289,9 @@ class WhisperGUI(QMainWindow, TabSetupMixin, InfoDialogsMixin):
         if getattr(self, "output_dir_source_checkbox", None):
             self.output_dir_source_checkbox.toggled.connect(self.update_output_dir_mode)
         self.initial_prompt.textChanged.connect(self.save_text_setting)
+        # Without this, Extra CLI Args only persisted on a clean window close, and
+        # any other realtime save wrote a stale value over it. See issue #22.
+        self.extra_cli_args.textChanged.connect(self.save_text_setting)
         self.tooltips_checkbox.toggled.connect(self.apply_tooltip_visibility)
         
         for checkbox in self.findChildren(QCheckBox):
@@ -2226,6 +2314,7 @@ class WhisperGUI(QMainWindow, TabSetupMixin, InfoDialogsMixin):
         self.settings["vad_device"] = self.vad_device.currentText()
         self.settings["diarize_backend"] = self.diarize_backend.currentText()
         self.settings["diarize_device"] = self.diarize_device.currentText()
+        self.settings["existing_output_mode"] = self._get_existing_output_mode()
         self.save_settings_to_file()
 
     def save_spinbox_setting(self):
@@ -2245,6 +2334,7 @@ class WhisperGUI(QMainWindow, TabSetupMixin, InfoDialogsMixin):
         """Save text field settings immediately"""
         self.settings["output_dir"] = self.output_dir.text()
         self.settings["initial_prompt"] = self.initial_prompt.toPlainText()
+        self.settings["extra_cli_args"] = self.extra_cli_args.toPlainText()
         self.save_settings_to_file()
 
     def save_converter_python_path(self):
@@ -3290,7 +3380,34 @@ class WhisperGUI(QMainWindow, TabSetupMixin, InfoDialogsMixin):
                 )
                 return None
             cmd.extend(extra_tokens)
+            self._warn_about_inert_extra_args(extra_args_text)
         return cmd
+
+    # Flags the exe only honours when its input is a wildcard or a directory.
+    # This GUI runs the exe once per file with an explicit path, so they are
+    # silently ignored -- which has confused several people (issues #20, #22).
+    INERT_EXTRA_ARGS = {
+        "--skip": "use the 'Existing Outputs' setting in Global Settings instead",
+        "--batch_recursive": "add the folder with 'Add Folder' instead",
+        "--check_files": None,
+    }
+
+    def _warn_about_inert_extra_args(self, extra_args_text):
+        """Tell the user once per run about extra args that cannot take effect."""
+        if getattr(self, "_inert_args_warned", False):
+            return
+        for flag, hint in self.INERT_EXTRA_ARGS.items():
+            if not self._extra_args_has_flag(flag, extra_args_text):
+                continue
+            self._inert_args_warned = True
+            message = (
+                f"Note: {flag} has no effect here. It only works when "
+                "Faster Whisper XXL is given a wildcard or a folder, and this app "
+                "runs it once per file."
+            )
+            if hint:
+                message += f" To do this, {hint}."
+            self._append_text_to_console(message + "\n")
 
     def start_processing(self):
         self.stop_requested = False
@@ -3312,6 +3429,8 @@ class WhisperGUI(QMainWindow, TabSetupMixin, InfoDialogsMixin):
         self._compute_type_override = None
         self._cpu_compute_override_applied = False
         self._model_download_cancelled = False
+        self._skipped_existing_count = 0
+        self._inert_args_warned = False
         if not self.get_output_dir():
             return
 
@@ -3340,6 +3459,17 @@ class WhisperGUI(QMainWindow, TabSetupMixin, InfoDialogsMixin):
             self.batch_index += 1
             next_file = self.pending_files.pop(0)
             total_display = self.batch_total if self.batch_total_known else "?"
+            should_skip, note = self._check_existing_outputs(next_file)
+            if should_skip:
+                self._skipped_existing_count += 1
+                logging.info("start_next_file: skipping %s (outputs exist)", next_file)
+                # Keep this to a single short line: resuming a large batch can
+                # skip hundreds of files, and full paths would swamp the console.
+                self._append_text_to_console(
+                    f"\nSKIPPED FILE {self.batch_index}/{total_display} • "
+                    f"{os.path.basename(next_file)} (outputs already exist)\n"
+                )
+                continue
             self._append_text_to_console(
                 f"\nPROCESSING FILE {self.batch_index}/{total_display} • {next_file}\n\n"
             )
@@ -3347,6 +3477,19 @@ class WhisperGUI(QMainWindow, TabSetupMixin, InfoDialogsMixin):
                 started = True
                 break
         if not started and not self.stop_requested:
+            # Nothing ran, so on_finished will not fire to hand control back.
+            # In serial mode it is what releases the next download, so do that
+            # here instead or the queue stalls. Gate on serial_download_waiting
+            # rather than isRunning(): the downloader emits `finished` from
+            # inside run(), so in download-all mode the thread can still report
+            # itself running and we would wrongly leave Run disabled.
+            if self.serial_download_waiting and self.downloader and self.downloader.isRunning():
+                self.serial_download_waiting = False
+                self.downloader.allow_next_download()
+                self.run_btn.setEnabled(False)
+                self.stop_btn.setEnabled(True)
+                return
+            self._report_skipped_summary()
             self.run_btn.setEnabled(True)
             self.stop_btn.setEnabled(False)
             self.stop_requested = False
@@ -3361,6 +3504,16 @@ class WhisperGUI(QMainWindow, TabSetupMixin, InfoDialogsMixin):
         self._current_output_basename = None
         self._single_output_line_emitted = False
         logging.info("run_transcription: input=%s", input_file)
+
+        # Check before touching the model so a fully-skipped batch never waits
+        # on a model download it will not use.
+        should_skip, note = self._check_existing_outputs(input_file)
+        if note:
+            self._append_text_to_console(f"{note}\n")
+        if should_skip:
+            logging.info("run_transcription: skipping %s (outputs exist)", input_file)
+            self._skipped_existing_count += 1
+            return False
 
         if not self.ensure_model_available():
             logging.info("run_transcription: model download cancelled or failed")
@@ -4206,13 +4359,14 @@ class WhisperGUI(QMainWindow, TabSetupMixin, InfoDialogsMixin):
             self.stop_btn.setEnabled(True)
             return
 
+        self._report_skipped_summary()
         self.run_btn.setEnabled(True)
         self.stop_btn.setEnabled(False)
         self.process = None
         self.downloader = None
         self.stop_requested = False
         self._force_output_suffix = False
-        
+
     def on_process_error(self, error):
         if error == QProcess.ProcessError.Crashed and self.transcription_completed_successfully:
             logging.info("Process crashed after successful transcription completion - ignoring crash error")
@@ -4350,6 +4504,7 @@ class WhisperGUI(QMainWindow, TabSetupMixin, InfoDialogsMixin):
             self.start_next_file()
         else:
             if not self.process and not self.pending_files:
+                self._report_skipped_summary()
                 self.run_btn.setEnabled(True)
                 self.stop_btn.setEnabled(False)
 
@@ -4735,6 +4890,10 @@ class WhisperGUI(QMainWindow, TabSetupMixin, InfoDialogsMixin):
         self.diarize_num_speakers.setValue(self.settings.get("diarize_num_speakers", 0))
         self.diarize_min_speakers.setValue(self.settings.get("diarize_min_speakers", 0))
         self.diarize_max_speakers.setValue(self.settings.get("diarize_max_speakers", 0))
+        if getattr(self, "existing_output_combo", None):
+            existing_mode = self.settings.get("existing_output_mode", "suffix")
+            existing_index = self.existing_output_combo.findData(existing_mode)
+            self.existing_output_combo.setCurrentIndex(existing_index if existing_index >= 0 else 0)
 
         all_checkboxes = {cb.objectName(): cb for cb in self.findChildren(QCheckBox) if cb.objectName()}
         checkbox_settings = self.settings.get("checkboxes", {})

--- a/src/gui_tabs.py
+++ b/src/gui_tabs.py
@@ -331,18 +331,51 @@ class TabSetupMixin:
         output_dir_layout.addWidget(self.browse_out_btn)
         layout.addRow(output_dir_label, output_dir_container)
 
+        # Both of these are single checkboxes; sharing one row keeps the
+        # Global Settings panel from overflowing its scroll area.
         self.output_dir_source_checkbox = QCheckBox("Use source folder")
         self.output_dir_source_checkbox.setObjectName("output_dir_source_checkbox")
         self.output_dir_source_checkbox.setToolTip("Save outputs next to each input file.")
-        layout.addRow("Output Location:", self.output_dir_source_checkbox)
 
-        self.output_name_match_checkbox = QCheckBox("Use input filename for outputs")
+        self.output_name_match_checkbox = QCheckBox("Use input filename")
         self.output_name_match_checkbox.setObjectName("output_name_match_checkbox")
         self.output_name_match_checkbox.setToolTip(
             "Prefer the original input name for outputs. A suffix may still be added to avoid conflicts."
         )
         self.output_name_match_checkbox.setChecked(True)
-        layout.addRow("Output Name:", self.output_name_match_checkbox)
+
+        output_toggles = QWidget()
+        output_toggles_layout = QHBoxLayout(output_toggles)
+        output_toggles_layout.setContentsMargins(0, 0, 0, 0)
+        output_toggles_layout.setSpacing(12)
+        output_toggles_layout.addWidget(self.output_dir_source_checkbox)
+        output_toggles_layout.addWidget(self.output_name_match_checkbox)
+        output_toggles_layout.addStretch()
+        output_toggles_label = QLabel("Output:")
+        output_toggles_label.setToolTip(
+            "Where outputs are saved, and whether they reuse the input filename."
+        )
+        layout.addRow(output_toggles_label, output_toggles)
+
+        existing_tip = (
+            "What to do when the outputs for a file already exist in the output folder.\n\n"
+            "Add suffix: name the new output e.g. 'video_mp4.srt' (default, current behavior).\n"
+            "Skip file: leave the existing outputs alone and move to the next file. "
+            "Useful for resuming an interrupted batch.\n"
+            "Overwrite: replace the existing outputs in place.\n\n"
+            "A file is only skipped when every selected output format is already present."
+        )
+        self.existing_output_combo = QComboBox()
+        for label, mode in (
+            ("Add suffix", "suffix"),
+            ("Skip file", "skip"),
+            ("Overwrite", "overwrite"),
+        ):
+            self.existing_output_combo.addItem(label, mode)
+        self.existing_output_combo.setToolTip(existing_tip)
+        existing_label = QLabel("Existing Outputs:")
+        existing_label.setToolTip(existing_tip)
+        layout.addRow(existing_label, self.existing_output_combo)
 
         self.model_combo = QComboBox()
         self.model_combo.setToolTip(

--- a/src/output_formats.py
+++ b/src/output_formats.py
@@ -434,3 +434,67 @@ def extra_args_has_flag(flag, text):
         return False
     pattern = re.compile(rf"(^|\s){re.escape(flag)}(=|\s|$)")
     return bool(pattern.search(text))
+
+
+# ---------------------------------------------------------------------------
+# Existing-output detection
+# ---------------------------------------------------------------------------
+
+# Maps a GUI output-format label to the filename suffix it produces for a run
+# with basename ``base`` (i.e. the output file is ``base`` + suffix).
+FORMAT_SUFFIXES = {
+    "json": ".json",
+    "vtt": ".vtt",
+    "srt": ".srt",
+    "lrc": ".lrc",
+    "tsv": ".tsv",
+    "txt (with timestamps)": ".txt",
+    "txt (sentences only)": "_sentences.txt",
+}
+
+# What the exe's ``--output_format all`` actually writes.
+ALL_FORMAT_SUFFIXES = (".json", ".vtt", ".srt", ".lrc", ".tsv", ".txt")
+
+
+def expected_output_suffixes(selected_formats):
+    """Filename suffixes a given GUI format selection is expected to produce.
+
+    *selected_formats* holds GUI checkbox labels (``"srt"``, ``"txt (sentences
+    only)"``, ``"all"``, ...). Returns a sorted, de-duplicated list. An empty or
+    unrecognised selection falls back to ``.srt``, matching ``build_command``'s
+    default when nothing is checked.
+    """
+    if "all" in (selected_formats or []):
+        return sorted(ALL_FORMAT_SUFFIXES)
+    suffixes = {
+        FORMAT_SUFFIXES[fmt]
+        for fmt in (selected_formats or [])
+        if fmt in FORMAT_SUFFIXES
+    }
+    if not suffixes:
+        return [".srt"]
+    return sorted(suffixes)
+
+
+def expected_output_paths(output_dir, basename, selected_formats):
+    """Absolute paths the run is expected to produce for *basename*."""
+    if not output_dir or not basename:
+        return []
+    return [
+        os.path.join(output_dir, f"{basename}{suffix}")
+        for suffix in expected_output_suffixes(selected_formats)
+    ]
+
+
+def find_existing_outputs(output_dir, basename, selected_formats):
+    """Split expected output paths into ``(existing, missing)``.
+
+    Callers treat "safe to skip" as ``existing and not missing``. This is
+    deliberately strict, because a batch interrupted partway through writing its formats
+    leaves some files missing, and that file should be redone rather than
+    silently skipped.
+    """
+    existing, missing = [], []
+    for path in expected_output_paths(output_dir, basename, selected_formats):
+        (existing if os.path.exists(path) else missing).append(path)
+    return existing, missing

--- a/src/utils.py
+++ b/src/utils.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import shutil
 from PyQt6.QtCore import Qt
+from config import HTTP_HEADERS
 
 def get_app_directory():
     """ Get the application's base directory consistently, whether running from source or as executable """
@@ -423,7 +424,7 @@ def download_7zr_portable(dest_dir=None):
     dest_path = os.path.join(dest_dir, '7zr.exe')
     try:
         logging.info(f"Downloading 7zr.exe to {dest_path}")
-        resp = requests.get(_7ZR_DOWNLOAD_URL, timeout=30)
+        resp = requests.get(_7ZR_DOWNLOAD_URL, timeout=30, headers=HTTP_HEADERS)
         resp.raise_for_status()
         with open(dest_path, 'wb') as f:
             f.write(resp.content)

--- a/src/ytdlp_utils.py
+++ b/src/ytdlp_utils.py
@@ -10,7 +10,7 @@ import importlib.util
 import shutil
 import subprocess
 
-from config import APP_VERSION, YTDLP_DEBUG_LOG_NAME, EXTERNAL_MODULE_DIR_NAME, YTDLP_UPDATE_FAILURE_COOLDOWN_HOURS
+from config import APP_VERSION, YTDLP_DEBUG_LOG_NAME, EXTERNAL_MODULE_DIR_NAME, YTDLP_UPDATE_FAILURE_COOLDOWN_HOURS, HTTP_HEADERS
 from utils import get_app_directory, get_settings_directory, get_portable_settings_directory, run_hidden_subprocess
 from python_utils import (
     get_external_python_modules_path, detect_python_runtime, get_python_info_script_path,
@@ -311,7 +311,7 @@ _YT_DLP_RELEASE_CACHE = {
     "timestamp": 0,
     "releases": None
 }
-GITHUB_HEADERS = {"User-Agent": f"Faster-Whisper-XXL-GUI/{APP_VERSION}"}
+GITHUB_HEADERS = dict(HTTP_HEADERS)
 
 
 def fetch_yt_dlp_releases(max_releases=30, cache_seconds=600):

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -15,6 +15,9 @@ from output_formats import (
     create_sentences_only,
     build_lrc_lines,
     extra_args_has_flag,
+    expected_output_suffixes,
+    expected_output_paths,
+    find_existing_outputs,
 )
 
 
@@ -494,3 +497,98 @@ class TestExtraArgsHasFlag:
 
     def test_substring_not_matched(self):
         assert extra_args_has_flag("--dia", "--diarize") is False
+
+
+# ---------------------------------------------------------------------------
+# expected_output_suffixes
+# ---------------------------------------------------------------------------
+
+class TestExpectedOutputSuffixes:
+    def test_single_format(self):
+        assert expected_output_suffixes(["srt"]) == [".srt"]
+
+    def test_multiple_formats_sorted_and_deduped(self):
+        assert expected_output_suffixes(["vtt", "json", "vtt"]) == [".json", ".vtt"]
+
+    def test_txt_variants_map_to_distinct_files(self):
+        assert expected_output_suffixes(["txt (with timestamps)"]) == [".txt"]
+        assert expected_output_suffixes(["txt (sentences only)"]) == ["_sentences.txt"]
+
+    def test_both_txt_variants(self):
+        assert expected_output_suffixes(
+            ["txt (with timestamps)", "txt (sentences only)"]
+        ) == [".txt", "_sentences.txt"]
+
+    def test_all_expands_to_every_written_format(self):
+        assert expected_output_suffixes(["all"]) == [
+            ".json", ".lrc", ".srt", ".tsv", ".txt", ".vtt"
+        ]
+
+    def test_all_wins_over_other_selections(self):
+        assert expected_output_suffixes(["srt", "all"]) == expected_output_suffixes(["all"])
+
+    def test_empty_selection_defaults_to_srt(self):
+        # Mirrors build_command, which falls back to srt when nothing is checked.
+        assert expected_output_suffixes([]) == [".srt"]
+        assert expected_output_suffixes(None) == [".srt"]
+
+    def test_unknown_format_ignored(self):
+        assert expected_output_suffixes(["bogus"]) == [".srt"]
+        assert expected_output_suffixes(["bogus", "vtt"]) == [".vtt"]
+
+
+# ---------------------------------------------------------------------------
+# expected_output_paths / find_existing_outputs
+# ---------------------------------------------------------------------------
+
+class TestExpectedOutputPaths:
+    def test_builds_paths_from_basename(self, tmp_path):
+        paths = expected_output_paths(str(tmp_path), "video", ["srt", "json"])
+        assert paths == [
+            os.path.join(str(tmp_path), "video.json"),
+            os.path.join(str(tmp_path), "video.srt"),
+        ]
+
+    def test_sentences_suffix_has_no_extra_dot(self, tmp_path):
+        paths = expected_output_paths(str(tmp_path), "video", ["txt (sentences only)"])
+        assert paths == [os.path.join(str(tmp_path), "video_sentences.txt")]
+
+    def test_missing_inputs_yield_nothing(self, tmp_path):
+        assert expected_output_paths("", "video", ["srt"]) == []
+        assert expected_output_paths(str(tmp_path), "", ["srt"]) == []
+
+
+class TestFindExistingOutputs:
+    def test_nothing_exists(self, tmp_path):
+        existing, missing = find_existing_outputs(str(tmp_path), "video", ["srt"])
+        assert existing == []
+        assert len(missing) == 1
+
+    def test_all_exist_means_safe_to_skip(self, tmp_path):
+        (tmp_path / "video.srt").write_text("x")
+        (tmp_path / "video.json").write_text("x")
+        existing, missing = find_existing_outputs(str(tmp_path), "video", ["srt", "json"])
+        assert len(existing) == 2
+        assert missing == []
+
+    def test_partial_outputs_are_not_skippable(self, tmp_path):
+        # An interrupted run leaves some formats behind; it must be redone.
+        (tmp_path / "video.srt").write_text("x")
+        existing, missing = find_existing_outputs(str(tmp_path), "video", ["srt", "json"])
+        assert [os.path.basename(p) for p in existing] == ["video.srt"]
+        assert [os.path.basename(p) for p in missing] == ["video.json"]
+
+    def test_suffixed_basename_checked_independently(self, tmp_path):
+        # video.srt existing must not make video_mp4 look complete.
+        (tmp_path / "video.srt").write_text("x")
+        existing, missing = find_existing_outputs(str(tmp_path), "video_mp4", ["srt"])
+        assert existing == []
+        assert len(missing) == 1
+
+    def test_sentences_only_run_ignores_plain_txt(self, tmp_path):
+        (tmp_path / "video.txt").write_text("x")
+        existing, missing = find_existing_outputs(
+            str(tmp_path), "video", ["txt (sentences only)"]
+        )
+        assert existing == []
+        assert [os.path.basename(p) for p in missing] == ["video_sentences.txt"]


### PR DESCRIPTION
Closes #20, #21, #22.

## #20. Skip or overwrite existing subtitle files

`--skip` never worked from Extra CLI Args: Faster Whisper XXL only honours it for wildcard or folder input, and the app runs it once per file with an explicit path. Adds an **Existing Outputs** setting in Global Settings with `Add suffix` (default, unchanged behaviour), `Skip file` and `Overwrite`.

A file is only skipped when every selected output format is present, so a run interrupted partway through writing its formats is redone rather than silently skipped. Verified across restarts, which is the actual resume case.

## #21. Antivirus false positives

Root cause is the unsigned PyInstaller build, which needs a code-signing certificate to fix properly. Mitigations in the meantime:

* UPX is now explicitly off. Builds were unpacked only because UPX was not installed; packed executables are a strong heuristic trigger.
* Excluded Qt modules the app never imports. This also brings the exe from 54.6 MB to 49.9 MB, under the 50 MB cap of Microsoft's false-positive submission portal.
* Every request now sends a real User-Agent instead of the default `python-requests` one.
* Documented the false positive and the workarounds in the README and Wiki.

## #22. Extra CLI Args

The args did reach the executable, but were only saved on a clean window close, and any other setting change overwrote them with a stale value. They are now saved as they are typed. The app also warns once per run about flags it cannot honour (`--skip`, `--batch_recursive`, `--check_files`).

## Also fixed

`_required_tab_bar_width` called the protected `QTabBar.tabSizeHint`, which raises under PyQt6 on the tab bar QTabWidget creates internally. It only runs in frozen builds, so it never showed from source, but there it raised from a Qt slot and aborted the process. Present since 1.11.0, and the reason the tab bar was permanently clipped.

## CI

Adds a workflow that runs the tests and a headless startup check on every push, builds the Windows exe, verifies it starts via a new `--selftest` flag, and reports its size and SHA256. Version tags attach the exe and checksum to a draft release.

## Testing

224 unit tests pass, and every commit passes independently. The GUI changes were verified by driving the real window headlessly against a stub executable: 22 end-to-end scenarios covering all three modes, plus batch and yt-dlp control flow.

The first CI run confirmed on real Windows that the packaged app still starts with the trimmed module list, and reported the exe at 49,940,582 bytes.

Not verified: an actual transcription against the real Faster Whisper XXL binary.